### PR TITLE
Add support for custom host/port

### DIFF
--- a/dist/nodecopter-client.js
+++ b/dist/nodecopter-client.js
@@ -1186,14 +1186,15 @@ var FilterWebGLCanvas = (function () {
     }
 
 
-    NS = function (div) {
+    NS = function (div, options) {
         setupCanvas(div);
         setupAvc();
 
+        var hostname = options.hostname || window.document.location.hostname;
+        var port = options.port || window.document.location.port;
+
         socket = new WebSocket(
-             'ws://' +
-            window.document.location.hostname + ':' +
-            window.document.location.port + '/dronestream'
+             'ws://' + hostname + ':' + port + '/dronestream'
         );
         socket.binaryType = 'arraybuffer';
         socket.onmessage = handleNalUnits;

--- a/dist/nodecopter-stream.js
+++ b/dist/nodecopter-stream.js
@@ -87,14 +87,15 @@
     }
 
 
-    NS = function (div) {
+    NS = function (div, options) {
         setupCanvas(div);
         setupAvc();
 
+        var hostname = options.hostname || window.document.location.hostname;
+        var port = options.port || window.document.location.port;
+
         socket = new WebSocket(
-             'ws://' +
-            window.document.location.hostname + ':' +
-            window.document.location.port + '/dronestream'
+             'ws://' + hostname + ':' + port + '/dronestream'
         );
         socket.binaryType = 'arraybuffer';
         socket.onmessage = handleNalUnits;


### PR DESCRIPTION
I needed to be able to override the port for the websocket connection (in order to make it coexist with a socket io connection). Hence this little patch.
