### PR TITLE
Support for passing an existing tcpVideoStream

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -13,23 +13,30 @@ module.exports.attach = function droneStream(server, options) {
     options = options || {};
     options.timeout = options.timeout || 4000;
     function init() {
-        var tcpVideoStream = new arDrone.Client.PngStream.TcpVideoStream(options),
-            p = new Parser();
+        
+        var tcpVideoStream, parser;
 
-        console.log("Connecting to drone on %s", options.ip || "192.168.1.1");
+        if (options.tcpVideoStream == null) {
+            tcpVideoStream = new arDrone.Client.PngStream.TcpVideoStream(options),
 
-        tcpVideoStream.connect(function () {
-            tcpVideoStream.pipe(p);
+            console.log("Connecting to drone on %s", options.ip || "192.168.1.1");
+
+            tcpVideoStream.connect();
+            tcpVideoStream.on('error', function (err) {
+                console.log('There was an error: %s', err.message);
+                tcpVideoStream.end();
+                tcpVideoStream.emit("end");
+                init();
+            });
+        } else {
+            tcpVideoStream = options.tcpVideoStream;
+        }
+
+        parser = new Parser();
+        tcpVideoStream.on('data', function(data) {
+            parser.write(data);
         });
-
-        tcpVideoStream.on('error', function (err) {
-            console.log('There was an error: %s', err.message);
-            tcpVideoStream.end();
-            tcpVideoStream.emit("end");
-            init();
-        });
-
-        p.on('data', function (data) {
+        parser.on('data', function (data) {
             sockets.forEach(function (socket) {
                 socket.send(data, {binary: true});
             });


### PR DESCRIPTION
Since the AR Drone supports only a single connection to the video
stream, it is sometimes required to re-use the same stream across an
application.

If no tcpvideostream is passed, the behavior is the same as before, nothing as changed. If a stream is passed, then it is re-used.

Related to this issue in node-ar-drone: https://github.com/felixge/node-ar-drone/issues/43
